### PR TITLE
Skillmons: Allow moves like 'Sleep Talk' to fail.

### DIFF
--- a/mods/skillmons/scripts.js
+++ b/mods/skillmons/scripts.js
@@ -279,6 +279,10 @@ exports.BattleScripts = {
 		} else if (target) {
 			hitResult = this.singleEvent('TryHit', moveData, {}, target, pokemon, move);
 		}
+		if (!hitResult) {
+			if (hitResult === false) this.add('-fail', target);
+			return false;
+		}
 
 		if (target && !isSecondary && !isSelf) {
 			hitResult = this.runEvent('TryPrimaryHit', target, pokemon, moveData);


### PR DESCRIPTION
TryHit event is used to determine if move can succeed to begin with. For
example, Sleep Talk and Snore check if the user sleeps. Synchronoise only
works on Pokemon of the same type. Sucker Punch only works when the
opponent wants to attack.