### PR TITLE
Skillmons: Fix damage from Recoil moves

### DIFF
--- a/mods/skillmons/scripts.js
+++ b/mods/skillmons/scripts.js
@@ -492,6 +492,7 @@ exports.BattleScripts = {
 		if (move.selfSwitch && pokemon.hp) {
 			pokemon.switchFlag = move.selfSwitch;
 		}
+		return damage;
 	},
 	comparePriority: function (a, b) {
 		a.priority = a.priority || 0;


### PR DESCRIPTION
People were complaining about Talonflame being broken, and I noticed that accidentally `return` statement wasn't copied.