### PR TITLE
Super Staff Bros Melee: add Jasmine

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -832,6 +832,9 @@ exports.Formats = [
 			if (name === 'gangnamstyle') {
 				this.add("c|+Gangnam Style|Here I Come, Rougher Than The Rest of 'Em.");
 			}
+			if (name === 'jasmine') {
+				this.add("c|~Jasmine|I'm still relevant!");
+			}
 			if (name === 'joim') {
 				let dice = this.random(3);
 				// Revisiting classics.
@@ -925,6 +928,9 @@ exports.Formats = [
 			}
 			if (name === 'gangnamstyle') {
 				this.add("c|+Gangnam Style|The Great Emeralds power allows me to feel... ");
+			}
+			if (name === 'jasmine') {
+				this.add("raw|<div class=\"broadcast-red\"><b>The server is restarting soon.</b><br />Please finish your battles quickly. No new battles can be started until the server resets in a few minutes.</div>");
 			}
 			if (name === 'joim') {
 				sentences = ['AVENGE ME, KIDS! AVEEEENGEEE MEEEEEE!!', 'OBEY!', '``This was a triumph, I\'m making a note here: HUGE SUCCESS.``', '``Remember when you tried to kill me twice? Oh how we laughed and laughed! Except I wasn\'t laughing.``', '``I\'m not even angry, I\'m being so sincere right now, even though you broke my heart and killed me. And tore me to pieces. And threw every piece into a fire.``'];

--- a/mods/seasonal/moves.js
+++ b/mods/seasonal/moves.js
@@ -127,6 +127,25 @@ exports.BattleMovedex = {
 		target: "normal",
 		type: "Dark",
 	},
+	reversetransform: {
+		num: -144,
+		accuracy: true,
+		category: "Status",
+		id: "reversetransform",
+		name: "Reverse Transform",
+		pp: 1,
+		noPPBoosts: true,
+		priority: 0,
+		flags: {protect: 1, mirror: 1, authentic: 1},
+		onHit: function (target, source) {
+			if (!target.transformInto(source, target)) {
+				return false;
+			}
+			target.canMegaEvo = false;
+		},
+		target: "nomral",
+		type: "Normal",
+	},
 	standingfull: {
 		num: -223,
 		accuracy: 100,

--- a/mods/seasonal/scripts.js
+++ b/mods/seasonal/scripts.js
@@ -36,6 +36,12 @@ exports.BattleScripts = {
 				baseSignatureMove: 'furyswipes', signatureMove: "Mother, Father, Gentleman",
 				evs: {hp:252, atk:252, def:4}, nature: 'Adamant',
 			},*/
+			'Jasmine': {
+				species: 'Mew', ability: 'Speed Boost', item: 'Focus Sash', gender: 'F',
+				moves: ['taunt', 'explosion', 'protect'],
+				baseSignatureMove: 'transform', signatureMove: "Reverse Transform",
+				evs: {hp:84, atk:84, def:84, spa:84, spd:84, spe:84}, nature: 'Quirky',
+			},
 			'Joim': {
 				species: 'Zapdos', ability: 'Tinted Lens', item: 'Life Orb', gender: 'M', shiny: true,
 				moves: ['thunderbolt', 'hurricane', 'quiverdance'],


### PR DESCRIPTION
It should be noted that Reverse Transform gives the opponent Reverse Transform, however they are unable to use it because they are not named "Jasmine" and instead the move just fails. I don't know if this is desirable behavior or not, but it probably prevents an endless battle. 